### PR TITLE
fix effect targets: disable per-request tracing, correct video content-type, pin a source oracle

### DIFF
--- a/.agents/skills/effect-v4/SKILL.md
+++ b/.agents/skills/effect-v4/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: effect-v4
+description: Write, review, benchmark, or upgrade Effect v4 beta code in this repository. Use for src/effect-router.ts, src/bun/effect.ts, src/node/effect.ts, effect/unstable/http, @effect/platform-bun, @effect/platform-node, core Effect/Layer/Context/Schema APIs, v3-to-v4 migrations, or Effect beta pin bumps. Verify unfamiliar APIs against the pinned repos/effect source oracle and keep all Effect packages on one exact beta.
+---
+
+# Effect v4
+
+The Bun and Node Effect targets share one Effect HTTP router and run on the exact
+Effect v4 beta recorded in [versions.json](versions.json). Ground claims in the
+checked-in implementation and pinned upstream source, not in remembered v3 APIs.
+
+## Authority order
+
+1. Treat the benchmark contract in `README.md` and the compiling files under `src/`
+   as the local behavior source of truth.
+2. Verify package APIs against installed typings and `repos/effect` at its pinned
+   release commit.
+3. Use `repos/effect/migration/` to translate v3 code. Use web documentation only
+   when the exact-beta source does not answer the question.
+
+Keep `repos/effect` read-only. Never edit it or import runtime code from it.
+
+## Read next
+
+- Read [references/core-patterns.md](references/core-patterns.md) for generators,
+  services, layers, typed errors, Promise boundaries, and high-value v3-to-v4
+  translations.
+- Read [references/http-server.md](references/http-server.md) before changing the
+  router, requests, responses, Bun/Node adapters, server layers, or runtime launch.
+- Read [references/upgrade-workflow.md](references/upgrade-workflow.md) before
+  changing an Effect beta pin or advancing the source-oracle submodule.
+
+## Workflow
+
+1. Read the affected benchmark source and its matching reference above.
+2. Search the exact source oracle before using an unfamiliar or unstable API:
+
+   ```sh
+   rg -n -- '<symbol>' repos/effect/packages
+   ```
+
+3. Preserve route parity between Bun and Node by changing shared behavior in
+   `src/effect-router.ts`; keep runtime-specific wiring in `src/bun/effect.ts` and
+   `src/node/effect.ts`.
+4. Preserve the benchmark semantics in `README.md`, including dynamic path/query
+   extraction, JSON parse-and-serialize behavior, streamed file responses, shared
+   background routes, and disabled server logging.
+5. Keep changes narrow. Do not add production-oriented middleware, tracing, or
+   abstractions that distort benchmark startup, memory, bundle size, or throughput.
+
+## Non-negotiables
+
+- Pin `effect`, `@effect/platform-bun`, and `@effect/platform-node` to the same exact
+  beta. Do not use `^`, `~`, or the floating `beta` dist-tag.
+- Import v4 HTTP APIs from `effect/unstable/http`; do not restore v3
+  `@effect/platform/Http*` imports.
+- Use `Effect.gen` with `yield*` for generator workflows and
+  `Effect.fn("name")(function*() { ... })` when a named Effect-returning function is
+  useful.
+- Define services with `Context.Service` and explicit layers. V4 does not generate a
+  default layer.
+- Model expected failures as typed tagged errors and recover with
+  `Effect.catchTag`/`Effect.catchTags` or `Match`, not manual `_tag` comparisons.
+- Use `Effect.tryPromise({ try, catch })` for fallible Promise boundaries.
+
+## Verification
+
+For source-or-skill edits, run the narrow relevant checks:
+
+```sh
+bun scripts/build-framework.ts bun/effect
+bun scripts/build-framework.ts node/effect
+```
+
+Run `bun run verify` when router or server behavior changes; it exercises the shared
+HTTP contract across the benchmark. After editing this skill, validate its frontmatter,
+metadata, JSON, and relative links.

--- a/.agents/skills/effect-v4/agents/openai.yaml
+++ b/.agents/skills/effect-v4/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Effect v4"
+  short_description: "Build and review exact-beta Effect v4 code"
+  default_prompt: "Use $effect-v4 to update the benchmark Effect HTTP implementation against its pinned beta."

--- a/.agents/skills/effect-v4/references/core-patterns.md
+++ b/.agents/skills/effect-v4/references/core-patterns.md
@@ -1,0 +1,81 @@
+# Effect v4 core patterns
+
+Use these as orientation, then confirm exact signatures in `repos/effect`. The beta
+source is authoritative.
+
+## Generator workflows
+
+Use `Effect.gen` and `yield*` for sequential Effect code:
+
+```ts
+const program = Effect.gen(function* () {
+  const value = yield* loadValue
+  return yield* persistValue(value)
+})
+```
+
+Use `Effect.fn("descriptiveName")(function* (...) { ... })` for reusable named
+Effect-returning functions when the name improves traces and diagnostics.
+
+## Services and layers
+
+Effect v4 replaces v3 `Context.Tag`, `Context.GenericTag`, and `Effect.Service` with
+`Context.Service`. Define the service shape and construct its layer explicitly:
+
+```ts
+interface ClockShape {
+  readonly now: Effect.Effect<number>
+}
+
+class Clock extends Context.Service<Clock, ClockShape>()("benchmark/Clock") {
+  static readonly Default = Layer.succeed(Clock, {
+    now: Effect.sync(() => Date.now())
+  })
+}
+```
+
+Use `Clock.of({...})` when constructing a service value for a test or local layer.
+Compose dependencies with `Layer.provide`, `Layer.provideMerge`, and `Layer.mergeAll`;
+verify the resulting requirements in the inferred `Layer.Layer<Out, Error, In>` type.
+
+## Typed expected failures
+
+Use `Data.TaggedError` for ordinary expected failures:
+
+```ts
+class InvalidInput extends Data.TaggedError("InvalidInput")<{
+  readonly input: unknown
+  readonly cause?: unknown
+}> {}
+```
+
+Use `Schema.TaggedErrorClass` when the error must participate in Schema
+encoding/decoding. Recover with `Effect.catchTag`, `Effect.catchTags`, `Match`, or a
+`Predicate.isTagged` guard; avoid direct `_tag` string comparisons.
+
+## Promise boundaries
+
+Use `Effect.tryPromise({ try, catch })` for a Promise that can reject and map the
+rejection into a typed error. Use `Effect.promise` only when rejection should be a
+defect.
+
+## High-value v3-to-v4 translations
+
+This table is historical recognition guidance, not a substitute for source lookup.
+The complete generated map is `repos/effect/migration/v3-to-v4.md`.
+
+| Effect v3 | Effect v4 |
+| --- | --- |
+| `Context.Tag`, `Context.GenericTag`, `Effect.Service` | `Context.Service` |
+| generated service `.Default` | explicit `Layer.succeed` / `Layer.effect` / `Layer.provide` |
+| `@effect/platform/HttpRouter` and related HTTP modules | `effect/unstable/http` |
+| `Effect.catchAll` / `catchAllCause` / `catchSome` | `Effect.catch` / `catchCause` / `catchFilter` |
+| `Either` | `Result`; use `Effect.fromResult(...)` in an Effect workflow |
+| `Schema.decodeUnknown` / `decode` / `encode` | `Schema.decodeUnknownEffect` / `decodeEffect` / `encodeEffect` |
+| `Schema.Literal(a, b)` / `Schema.Union(A, B)` | `Schema.Literals([a, b])` / `Schema.Union([A, B])` |
+| `Schema.Record({ key, value })` | `Schema.Record(key, value)` |
+| `.annotations({...})` | `.annotate({...})` |
+| `Effect.runtime<R>()` + `Runtime.runPromise` | `Effect.context<R>()` + `Effect.runPromiseWith` |
+
+For any beta-to-beta drift, search the pinned source and migration files instead of
+extending this table from memory.

--- a/.agents/skills/effect-v4/references/http-server.md
+++ b/.agents/skills/effect-v4/references/http-server.md
@@ -1,0 +1,93 @@
+# Effect v4 HTTP server surface
+
+This repository uses the beta HTTP stack from `effect/unstable/http`, with official
+Bun and Node adapters. The compile-checked local implementation is the first source of
+truth:
+
+- `src/effect-router.ts` owns shared routes and handlers.
+- `src/bun/effect.ts` owns Bun server/runtime wiring.
+- `src/node/effect.ts` owns Node server/runtime wiring.
+
+## Router and handlers
+
+Import the grouped HTTP modules from the unstable barrel:
+
+```ts
+import {
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse
+} from "effect/unstable/http"
+```
+
+At beta.102, `HttpRouter.route(method, path, handler)` accepts a static response, an
+Effect producing a response, or a request-to-Effect function. `HttpRouter.addAll`
+combines route values into the router layer used by both runtimes.
+
+Use the services exposed by the route context:
+
+- `yield* HttpRouter.params` for path parameters.
+- `yield* HttpServerRequest.ParsedSearchParams` for parsed query parameters.
+- `yield* HttpServerRequest.HttpServerRequest` for the request service.
+- `yield* request.json` to parse a JSON request body.
+
+Build responses with `HttpServerResponse`. The current benchmark uses `text`,
+`jsonUnsafe`, and `file`; preserve their externally observable contract when changing
+handlers. `file` relies on platform services and is intentionally used for the
+streamed-video route.
+
+Verify signatures in:
+
+```text
+repos/effect/packages/effect/src/unstable/http/HttpRouter.ts
+repos/effect/packages/effect/src/unstable/http/HttpServerRequest.ts
+repos/effect/packages/effect/src/unstable/http/HttpServerResponse.ts
+```
+
+## Server layers
+
+Build one application layer from the shared router:
+
+```ts
+const app = HttpRouter.serve(effectRouter, {
+  disableLogger: true,
+  disableListenLog: true
+})
+```
+
+Keep both logging options disabled: request and listen logging change benchmark work
+and output.
+
+Provide the runtime adapter outside the shared router:
+
+```ts
+Layer.provide(BunHttpServer.layer({ port: 3000 }))
+Layer.provide(NodeHttpServer.layer(() => createServer(), { port: 3000 }))
+```
+
+Launch the complete layer with the matching runtime:
+
+```ts
+BunRuntime.runMain(Layer.launch(app))
+NodeRuntime.runMain(Layer.launch(app))
+```
+
+The adapter implementations are:
+
+```text
+repos/effect/packages/platform-bun/src/BunHttpServer.ts
+repos/effect/packages/platform-node/src/NodeHttpServer.ts
+```
+
+Do not move adapter services into `src/effect-router.ts`; that would make the shared
+router runtime-specific.
+
+## Benchmark boundaries
+
+- Keep route behavior identical across Bun and Node.
+- Keep dynamic background routes sourced from `src/extra-routes.mjs`.
+- Do not hard-code query offsets or benchmark fixture values.
+- Do not add default middleware, logging, tracing, or per-request allocation solely
+  for production ergonomics.
+- Treat any unstable HTTP API change during a beta bump as a behavior change: rebuild
+  both targets and run the verifier.

--- a/.agents/skills/effect-v4/references/upgrade-workflow.md
+++ b/.agents/skills/effect-v4/references/upgrade-workflow.md
@@ -1,0 +1,74 @@
+# Bumping the Effect v4 beta
+
+Advance package pins and the source oracle as one reviewed unit.
+
+## 1. Resolve a published version
+
+Query the registry; do not infer the latest beta from GitHub `main`:
+
+```sh
+npm view effect@beta version
+npm view @effect/platform-bun@beta version
+npm view @effect/platform-node@beta version
+```
+
+Stop if the three packages do not have a matching published beta.
+
+## 2. Update exact pins together
+
+Update these `package.json` dependencies to the same exact version:
+
+- `effect`
+- `@effect/platform-bun`
+- `@effect/platform-node`
+
+Do not use a range or the floating `beta` dist-tag. Regenerate the lockfile with the
+package manager chosen for the change; do not hand-edit a binary lockfile. Inspect the
+lockfile diff for unrelated dependency churn.
+
+## 3. Advance the source oracle
+
+Fetch tags and check out the release tag matching the package version:
+
+```sh
+git -C repos/effect fetch --tags
+git -C repos/effect checkout "effect@<version>"
+git -C repos/effect rev-parse HEAD
+git -C repos/effect tag --points-at HEAD
+git add repos/effect
+```
+
+Confirm the three package manifests inside the submodule report the same version:
+
+```text
+repos/effect/packages/effect/package.json
+repos/effect/packages/platform-bun/package.json
+repos/effect/packages/platform-node/package.json
+```
+
+Update `versions.json` with the version, release tag, and peeled commit. The gitlink
+and npm pins are independent facts; verify both.
+
+## 4. Check migration notes and behavior
+
+Read release notes between the old and new betas. Search
+`repos/effect/migration/` and the exact source for every affected unstable HTTP API.
+Then run:
+
+```sh
+bun scripts/build-framework.ts bun/effect
+bun scripts/build-framework.ts node/effect
+bun run verify
+```
+
+Treat changed routing, request parsing, response streaming, logging, startup, or
+runtime teardown as benchmark-significant even if typechecking stays green.
+
+## Stop conditions
+
+Pause instead of reaching for a compatibility workaround when:
+
+- a matching platform beta or release tag does not exist;
+- the needed behavior is only on unreleased `main`;
+- Bun and Node adapters require different externally observable route behavior;
+- the verifier regresses because of the beta rather than a local implementation bug.

--- a/.agents/skills/effect-v4/versions.json
+++ b/.agents/skills/effect-v4/versions.json
@@ -1,0 +1,11 @@
+{
+  "effect": "4.0.0-beta.102",
+  "@effect/platform-bun": "4.0.0-beta.102",
+  "@effect/platform-node": "4.0.0-beta.102",
+  "typescript": "7.0.2",
+  "source_oracle": {
+    "path": "repos/effect",
+    "tag": "effect@4.0.0-beta.102",
+    "commit": "de2a9a69099993087e57c64df58537c765ac0224"
+  }
+}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "repos/effect"]
+	path = repos/effect
+	url = https://github.com/Effect-TS/effect.git
+	branch = main

--- a/src/bun/effect.ts
+++ b/src/bun/effect.ts
@@ -1,11 +1,15 @@
 import { BunHttpServer, BunRuntime } from '@effect/platform-bun'
-import { Layer } from 'effect'
+import { Layer, References } from 'effect'
 import { HttpRouter } from 'effect/unstable/http'
 import { effectRouter } from '../effect-router'
 
 const app = HttpRouter.serve(effectRouter, {
 	disableLogger: true,
 	disableListenLog: true
-}).pipe(Layer.provide(BunHttpServer.layer({ port: 3000 })))
+}).pipe(
+	Layer.provide(BunHttpServer.layer({ port: 3000 })),
+	// beta.102 traces every request by default; disableLogger does not cover the tracer middleware
+	Layer.provide(Layer.succeed(References.TracerEnabled)(false))
+)
 
 BunRuntime.runMain(Layer.launch(app))

--- a/src/effect-router.ts
+++ b/src/effect-router.ts
@@ -18,7 +18,7 @@ export const effectRouter = HttpRouter.addAll([
 		'GET',
 		'/video',
 		HttpServerResponse.file('public/kyuukurarin.mp4', {
-			contentType: 'video/mp4'
+			headers: { 'content-type': 'video/mp4' }
 		})
 	),
 	HttpRouter.route(

--- a/src/node/effect.ts
+++ b/src/node/effect.ts
@@ -1,5 +1,5 @@
 import { NodeHttpServer, NodeRuntime } from '@effect/platform-node'
-import { Layer } from 'effect'
+import { Layer, References } from 'effect'
 import { HttpRouter } from 'effect/unstable/http'
 import { createServer } from 'node:http'
 import { effectRouter } from '../effect-router'
@@ -8,7 +8,9 @@ const app = HttpRouter.serve(effectRouter, {
 	disableLogger: true,
 	disableListenLog: true
 }).pipe(
-	Layer.provide(NodeHttpServer.layer(() => createServer(), { port: 3000 }))
+	Layer.provide(NodeHttpServer.layer(() => createServer(), { port: 3000 })),
+	// beta.102 traces every request by default; disableLogger does not cover the tracer middleware
+	Layer.provide(Layer.succeed(References.TracerEnabled)(false))
 )
 
 NodeRuntime.runMain(Layer.launch(app))


### PR DESCRIPTION
This PR fixes two issues in the Effect targets and pins the Effect source so the fixes stay verifiable. The main change disables per-request tracing that Effect v4 enables by default. In an A/B run on my machine (an M-series MacBook, not the README test machine, so treat the numbers as relative) the ping route went from about 37-39k to 64-68k req/s, with bombardier confirming 64.7k after the fix. Startup dropped from 107.6 ms to 53.9 ms on the same machine.

## Tracing was the fixed per-request cost

In the published README table the Effect targets averaged about 44.5k req/s on Bun, below express on Bun at 49k, while the video route was near elysia. The simplest routes were the slowest relative to peers, which pointed at fixed per-request overhead rather than routing cost.

I verified the cause in the pinned effect@4.0.0-beta.102 source. HttpRouter.serve wraps every request in HttpMiddleware.tracer unconditionally (packages/effect/src/unstable/http/HttpEffect.ts, lines 89-91). The `disableLogger` option only removes the logger middleware, and References.TracerEnabled defaults to true. Even with no tracing exporter configured, each request builds a NativeSpan with two random hex id loops, parses trace-context headers, and schedules a post-response task that runs `new URL()`, redacts headers twice, and writes roughly 10-15 span attributes (HttpMiddleware.ts, lines 181-237).

The fix in src/bun/effect.ts and src/node/effect.ts adds `Layer.provide(Layer.succeed(References.TracerEnabled)(false))` with a one-line comment. This mirrors the framework's own layerTracerDisabledForUrls pattern (HttpMiddleware.ts, line 114).

## Video content-type

src/effect-router.ts passed `{ contentType: 'video/mp4' }` to HttpServerResponse.file. That option is silently ignored in beta.102. HttpPlatform.fileResponse reads only offset, bytesToRead, headers, status, and statusText, and the option is even typed away via Omit in the service signature. The mp4 route only worked because MIME inference from the file extension filled the header in. I now pass `{ headers: { 'content-type': 'video/mp4' } }`, which removes that dependency.

## Source oracle

The first commit adds an agent skill at .agents/skills/effect-v4 and pins the Effect repo as a git submodule at tag effect@4.0.0-beta.102 (commit de2a9a6, https://github.com/Effect-TS/effect.git) under repos/effect. The v4 HTTP APIs are unstable, so future beta bumps can be checked against the exact source instead of remembered v3 APIs. The skill's versions.json records the package pins and the oracle commit, and its upgrade workflow updates the npm pins and the submodule tag as one reviewed unit.

## Verification

Both targets build with `bun scripts/build-framework.ts bun/effect` and `bun scripts/build-framework.ts node/effect` and pass the repo's full verify sweep.
