### PR TITLE
Verify the query and JSON contract the README already mandates, fix the 20 implementations that failed it

### DIFF
--- a/bench.ts
+++ b/bench.ts
@@ -322,10 +322,18 @@ export const validateServer = async (index: Response) => {
 	if (!query.headers.get('X-Powered-By')?.includes('benchmark'))
 		throw new Error('Query: X-Powered-By not match')
 
+	const multiQuery = await fetch(`${baseUrl}/id/1?name=alice&id=1`)
+	if ((await multiQuery.text()) !== '1 alice')
+		throw new Error('Query: Multi-param result not match')
+
+	const missingQuery = await fetch(`${baseUrl}/id/1?id=1`)
+	if ((await missingQuery.text()) !== '1 ')
+		throw new Error('Query: Missing-param result not match')
+
 	const body = await fetch(`${baseUrl}/json`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ hello: 'world' })
+		body: '{ "hello" : "world" }'
 	})
 
 	if ((await body.text()) !== JSON.stringify({ hello: 'world' }))

--- a/dev/adonis/start/routes.ts
+++ b/dev/adonis/start/routes.ts
@@ -35,6 +35,6 @@ Route.get('/video', ({ response }) => {
 Route.get('/id/:id', ({ params, request, response }) => {
   response.header('x-powered-by', 'benchmark')
 
-  return `${params.id} ${request.qs().name}`
+  return `${params.id} ${request.qs().name ?? ''}`
 })
 Route.post('/json', ({ request }) => request.body())

--- a/dev/nest-node/src/app.controller.ts
+++ b/dev/nest-node/src/app.controller.ts
@@ -34,7 +34,7 @@ export class AppController {
   @Header('content-type', 'text/plain')
   @Header('x-powered-by', 'benchmark')
   getCompose(@Param('id') id: string, @Query('name') name: string) {
-    return `${id} ${name}`;
+    return `${id} ${name ?? ''}`;
   }
 
   @Post('/json')

--- a/src/bun/bun-web-standard.ts
+++ b/src/bun/bun-web-standard.ts
@@ -28,7 +28,7 @@ Bun.serve({
 
 					if (!rest)
 						return new Response(
-							`${id} ${url.searchParams.get('name')}`,
+							`${id} ${url.searchParams.get('name') ?? ''}`,
 							{
 								headers: {
 									'x-powered-by': 'benchmark'

--- a/src/bun/bun.ts
+++ b/src/bun/bun.ts
@@ -29,14 +29,14 @@ Bun.serve({
 					s = url.indexOf('/', 11),
 					qi = url.indexOf('?', s + 1)
 
-				const nameIdx = url.indexOf('name=', qi + 1)
-				const nameEndIdx = url.indexOf('&', nameIdx + 1)
+				const name =
+					qi === -1
+						? ''
+						: (new URLSearchParams(url.substring(qi + 1)).get(
+								'name'
+							) ?? '')
 				return new Response(
-					`${request.params.id} ${
-						nameEndIdx === -1
-							? url.substring(nameIdx + 5)
-							: url.substring(nameIdx + 5, nameEndIdx)
-					}`,
+					`${request.params.id} ${name}`,
 					queryHeaders
 				)
 			}
@@ -74,19 +74,12 @@ Bun.serve({
 					if (queryIndex === -1 || path.indexOf('/', 3) !== -1)
 						return notFound
 
-					const nameQueryIdx = url.indexOf('name=', queryIndex + 1)
-					if (nameQueryIdx === -1) return notFound
-
-					const nameQueryEndIdx = url.indexOf('&', nameQueryIdx + 1)
+					const name =
+						new URLSearchParams(url.substring(queryIndex + 1)).get(
+							'name'
+						) ?? ''
 					return new Response(
-						`${path.substring(3, queryIndex)} ${
-							nameQueryEndIdx === -1
-								? url.substring(nameQueryIdx + 5)
-								: url.substring(
-										nameQueryIdx + 5,
-										nameQueryEndIdx
-									)
-						}`,
+						`${path.substring(3, queryIndex)} ${name}`,
 						queryHeaders
 					)
 				}

--- a/src/bun/elysia.ts
+++ b/src/bun/elysia.ts
@@ -11,7 +11,7 @@ app.get('/', 'Hi')
 	.get('/id/:id', (c) => {
 		c.set.headers['x-powered-by'] = 'benchmark'
 
-		return `${c.params.id} ${c.query.name}`
+		return `${c.params.id} ${c.query.name ?? ''}`
 	})
 	.post(
 		'/json',

--- a/src/bun/express.ts
+++ b/src/bun/express.ts
@@ -22,6 +22,6 @@ app
 	.get('/id/:id', ({ params: { id }, query: { name } }, res) => {
 		res.setHeader('x-powered-by', 'benchmark')
 			.setHeader('content-type', 'text/plain')
-			.send(`${id} ${name}`)
+			.send(`${id} ${name ?? ''}`)
 	})
 	.listen(3000)

--- a/src/bun/h3.ts
+++ b/src/bun/h3.ts
@@ -44,7 +44,7 @@ router.get(
 		setResponseHeader(event, 'content-type', 'text/plain')
 		setResponseHeader(event, 'x-powered-by', 'benchmark')
 
-		return `${event.context.params?.id} ${query.name}`
+		return `${event.context.params?.id} ${query.name ?? ''}`
 	})
 )
 

--- a/src/bun/hono.ts
+++ b/src/bun/hono.ts
@@ -14,7 +14,7 @@ app.get('/', (c) => c.text('Hi'))
     .post('/json', (c) => c.req.json().then(c.json))
     .get('/id/:id', (c) => {
         const id = c.req.param('id')
-        const name = c.req.query('name')
+        const name = c.req.query('name') ?? ''
 
         c.header('x-powered-by', 'benchmark')
 

--- a/src/deno/acorn.ts
+++ b/src/deno/acorn.ts
@@ -14,7 +14,7 @@ app.get('/video', async () =>
 	})
 )
 app.get('/id/:id', async (ctx) => {
-	return new Response(`${ctx.params.id} ${(await ctx.queryParams())?.name}`, {
+	return new Response(`${ctx.params.id} ${(await ctx.queryParams())?.name ?? ''}`, {
 		headers: {
 			'x-powered-by': 'benchmark'
 		}

--- a/src/deno/deno-web-standard.ts
+++ b/src/deno/deno-web-standard.ts
@@ -25,7 +25,7 @@ Deno.serve({ port: 3000 }, async (request) => {
 
                 if (!rest)
                     return new Response(
-                        `${id} ${url.searchParams.get('name')}`,
+                        `${id} ${url.searchParams.get('name') ?? ''}`,
                         {
                             headers: {
                                 'x-powered-by': 'benchmark'

--- a/src/deno/deno.ts
+++ b/src/deno/deno.ts
@@ -52,16 +52,12 @@ Deno.serve({ port: 3000 }, (req) => {
 				if (queryIndex === -1 || path.indexOf('/', 3) !== -1)
 					return notFound
 
-				const nameQueryIdx = url.indexOf('name=', queryIndex + 1)
-				if (nameQueryIdx === -1) return notFound
-
-				const nameQueryEndIdx = url.indexOf('&', nameQueryIdx + 1)
+				const name =
+					new URLSearchParams(url.substring(queryIndex + 1)).get(
+						'name'
+					) ?? ''
 				return new Response(
-					`${path.substring(3, queryIndex)} ${
-						nameQueryEndIdx === -1
-							? url.substring(nameQueryIdx + 5)
-							: url.substring(nameQueryIdx + 5, nameQueryEndIdx)
-					}`,
+					`${path.substring(3, queryIndex)} ${name}`,
 					queryHeaders
 				)
 			}

--- a/src/deno/hono.ts
+++ b/src/deno/hono.ts
@@ -15,7 +15,7 @@ app.get('/', (c) => c.text('Hi'))
 	.post('/json', async (c) => c.json(await c.req.json()))
 	.get('/id/:id', (c) => {
 		const id = c.req.param('id')
-		const name = c.req.query('name')
+		const name = c.req.query('name') ?? ''
 
 		c.header('x-powered-by', 'benchmark')
 

--- a/src/deno/oak.ts
+++ b/src/deno/oak.ts
@@ -22,7 +22,7 @@ router.get("/", (context) => {
 		context.response.headers.append("x-powered-by", "benchmark")
 		context.response.body = `${
 			context.params.id
-		} ${context.request.url.searchParams.get("name")}`
+		} ${context.request.url.searchParams.get("name") ?? ""}`
 	})
 	.post("/json", async (context) => {
 		context.response.body = await context.request.body.json()

--- a/src/node/adonis/start/routes.js
+++ b/src/node/adonis/start/routes.js
@@ -17,7 +17,7 @@ Route_1.default.get('/video', ({ response }) => {
 });
 Route_1.default.get('/id/:id', ({ params, request, response }) => {
     response.header('x-powered-by', 'benchmark');
-    return `${params.id} ${request.qs().name}`;
+    return `${params.id} ${request.qs().name ?? ''}`;
 });
 Route_1.default.post('/json', ({ request }) => request.body());
 //# sourceMappingURL=routes.js.map

--- a/src/node/elysia.ts
+++ b/src/node/elysia.ts
@@ -12,7 +12,7 @@ app.get('/', () => 'Hi')
 	.get('/id/:id', (c) => {
 		c.set.headers['x-powered-by'] = 'benchmark'
 
-		return `${c.params.id} ${c.query.name}`
+		return `${c.params.id} ${c.query.name ?? ''}`
 	})
 	.post(
 		'/json',

--- a/src/node/express.js
+++ b/src/node/express.js
@@ -22,6 +22,6 @@ app
 	.get('/id/:id', ({ params: { id }, query: { name } }, res) => {
 		res.setHeader('x-powered-by', 'benchmark')
 			.setHeader('content-type', 'text/plain')
-			.send(`${id} ${name}`)
+			.send(`${id} ${name ?? ''}`)
 	})
 	.listen(3000)

--- a/src/node/fastify.js
+++ b/src/node/fastify.js
@@ -19,7 +19,7 @@ server.get("/", (req, res) => "Hi")
       res
     ) => {
       res.header("x-powered-by", "benchmark");
-      return `${req.params.id} ${req.query.name}`;
+      return `${req.params.id} ${req.query.name ?? ''}`;
     }
   )
   .post(

--- a/src/node/h3.js
+++ b/src/node/h3.js
@@ -46,7 +46,7 @@ router.get(
 		setResponseHeader(event, 'content-type', 'text/plain')
 		setResponseHeader(event, 'x-powered-by', 'benchmark')
 
-		return `${event.context.params.id} ${query.name}`
+		return `${event.context.params.id} ${query.name ?? ''}`
 	})
 )
 

--- a/src/node/hono.js
+++ b/src/node/hono.js
@@ -18,7 +18,7 @@ app.get("/", (c) => c.text("Hi"))
 	.post("/json", (c) => c.req.json().then(c.json))
 	.get("/id/:id", (c) => {
 		const id = c.req.param("id")
-		const name = c.req.query("name")
+		const name = c.req.query("name") ?? ""
 
 		c.header("x-powered-by", "benchmark")
 

--- a/src/node/hyper-express.js
+++ b/src/node/hyper-express.js
@@ -24,7 +24,7 @@ app.get('/id/:id', (req, res) => {
 	res.header('x-powered-by', 'benchmark')
 	res.header('content-type', 'text/plain')
 
-	res.send(`${req.path_parameters.id} ${req.query_parameters.name}`)
+	res.send(`${req.path_parameters.id} ${req.query_parameters.name ?? ''}`)
 })
 
 app.post('/json', async (req, res) => {

--- a/src/node/koa.js
+++ b/src/node/koa.js
@@ -27,7 +27,7 @@ router
         ctx.body = createReadStream('public/kyuukurarin.mp4')
     })
     .get('/id/:id', (ctx) => {
-        ctx.body = `${ctx.params.id} ${ctx.query.name}`
+        ctx.body = `${ctx.params.id} ${ctx.query.name ?? ''}`
         ctx.set('x-powered-by', 'benchmark')
     })
     .post('/json', (ctx) => {

--- a/src/node/nest/src/app.controller.js
+++ b/src/node/nest/src/app.controller.js
@@ -30,7 +30,7 @@ let AppController = class AppController {
         });
     }
     getCompose(id, name) {
-        return `${id} ${name}`;
+        return `${id} ${name ?? ''}`;
     }
     postMirror(body) {
         return body;

--- a/src/node/ultimate-express.js
+++ b/src/node/ultimate-express.js
@@ -27,7 +27,7 @@ app.post('/json', uExpress.json(), ({ body }, res) => {
 app.get('/id/:id', ({ params: { id }, query: { name } }, res) => {
 	res.setHeader('x-powered-by', 'benchmark')
 		.setHeader('content-type', 'text/plain')
-		.send(`${id} ${name}`)
+		.send(`${id} ${name ?? ''}`)
 })
 
 app.listen(3000, () => {})


### PR DESCRIPTION
The README mandates that `GET /id/:id` implementations must not use a hardcoded string or index to extract the querystring, that `/id/1?name=alice&id=1` must return `1 alice`, and that `/id/1?id=1` must return `1 ` with a trailing space (README, lines 76 to 84). validateServer in bench.ts could not detect violations of either MUST rule. It only probed `/id/1?name=bun`, which a hardcoded extraction passes. The JSON probe sent `JSON.stringify({ hello: 'world' })` and expected the same byte string back, so an implementation that echoes the raw request body without parsing it also passed.

The first commit (b013228) hardens the probes. `/id/1?name=alice&id=1` must now return `1 alice`, `/id/1?id=1` must return `1 `, and the JSON probe sends the non-canonical body `{ "hello" : "world" }` while still expecting the compact `{"hello":"world"}`, so only implementations that parse and re-serialize the body pass.

Running the hardened probes exposed real violations. 20 of the 26 targets runnable on my machine failed the missing-name case, and only bun/effect, node/effect, and node/uws passed everything. Two implementations used the forbidden `indexOf('name=')` plus substring extraction and returned 404 when `name` was absent: src/bun/bun.ts (in two places, including its `fetch()` fallback branch) and src/deno/deno.ts. The rest already used their framework's query API but rendered `1 undefined` or `1 null` when `name` was missing.

The second commit (76d4176) fixes them in two tiers. bun.ts and deno.ts now extract `name` through URLSearchParams with an empty-string fallback. The remaining implementations get a one-line `?? ''` fallback (elysia, express, fastify, h3, hono, hyper-express, koa, ultimate-express, adonis, and nest on node, the bun and deno variants, plus deno/acorn, deno/oak, deno/hono, bun/bun-web-standard, and deno/deno-web-standard). dev/adonis and dev/nest-node get the same one-line fix so the generated files and their TypeScript sources stay in sync. The commit touches 23 files, 38 insertions, 49 deletions.

After the fixes, `bun run verify` passes all 26 frameworks, including the five Deno targets under Deno 2.9.4. Query-route scores for bun/bun and deno/deno may shift once re-benchmarked because they now parse the querystring dynamically instead of by index, which is what the README already required.
