### PR TITLE
add(lib): tspace-spear benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "koa-router": "^14.0.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
+    "tspace-spear": "^1.3.1",
     "typebox": "^1.3.8",
-    "typescript": "^7.0.2",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.69.0",
-    "ultimate-express": "^2.2.0"
+    "typescript": "^5.0.0",
+    "ultimate-express": "^2.2.0",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.69.0"
   },
   "devDependencies": {
     "@hono/node-server": "^2.0.12",

--- a/src/bun/tspace-spear.ts
+++ b/src/bun/tspace-spear.ts
@@ -1,0 +1,27 @@
+import { Spear }  from 'tspace-spear'
+import { extraRoutes } from '../extra-routes.mjs'
+import http  from 'http'
+
+const app = new Spear({
+    adapter : http
+})
+.useBodyParser()
+
+for (const route of extraRoutes) {
+    
+    app
+    .get(route, () => 'ok')
+    .post(`${route}/submit`, () => 'ok')
+}
+  
+app.get('/', () => 'Hi')
+    .get('/video', ({ res }) => {
+        return res.serveMedia('public/kyuukurarin.mp4');
+    })
+    .get('/id/:id', (ctx) => {
+        ctx.res.set('x-powered-by','benchmark');
+        return `${ctx.params.id} ${ctx.query.name}`;
+    })
+    .post('/json',(ctx) => ({ body: ctx.body }))
+
+    .listen(3000)

--- a/src/node/tspace-spear.js
+++ b/src/node/tspace-spear.js
@@ -1,0 +1,29 @@
+const { Spear } = require('tspace-spear')
+const { extraRoutes } = require('../extra-routes.mjs')
+const uWS = require('uWebSockets.js')
+// const net = require('net')
+// const http = require('http')
+
+const app = new Spear({
+    adapter : uWS // net , http
+})
+.useBodyParser()
+
+for (const route of extraRoutes) {
+    
+    app
+    .get(route, () => 'ok')
+    .post(`${route}/submit`, () => 'ok')
+}
+  
+app.get('/', () => 'Hi')
+    .get('/video', ({ res }) => {
+        return res.serveMedia('public/kyuukurarin.mp4');
+    })
+    .get('/id/:id', (ctx) => {
+        ctx.res.set('x-powered-by','benchmark');
+        return `${ctx.params.id} ${ctx.query.name}`;
+    })
+    .post('/json',(ctx) => ({ body: ctx.body }))
+
+    .listen(3000)


### PR DESCRIPTION
## Summary

Add `tspace-spear` to the benchmark suite.

### Notes

- Uses the `uWebSockets.js` adapter for Node.js.
- Uses the `http` adapter for Bun.
- Implements the same benchmark endpoints as the other frameworks.
- Matches the existing response behavior for fair benchmarking.